### PR TITLE
Update queries to support Postgres

### DIFF
--- a/catalog/src/main/resources/org/killbill/billing/catalog/dao/CatalogOverridePhaseDefinitionSqlDao.sql.stg
+++ b/catalog/src/main/resources/org/killbill/billing/catalog/dao/CatalogOverridePhaseDefinitionSqlDao.sql.stg
@@ -60,8 +60,8 @@ select <allTableFields()>
 from <tableName()>
 where parent_phase_name = :parentPhaseName
 and currency = :currency
-and (fixed_price = :fixedPrice or (fixed_price is null and :fixedPrice is null))
-and (recurring_price = :recurringPrice or (recurring_price is null and :recurringPrice is null))
+and (fixed_price = :fixedPrice or coalesce(fixed_price, :fixedPrice) is null)
+and (recurring_price = :recurringPrice or coalesce(recurring_price, :recurringPrice) is null)
 and tenant_record_id = :tenantRecordId
 ;
 >>

--- a/payment/src/main/resources/org/killbill/billing/payment/dao/PaymentMethodSqlDao.sql.stg
+++ b/payment/src/main/resources/org/killbill/billing/payment/dao/PaymentMethodSqlDao.sql.stg
@@ -105,7 +105,7 @@ from <tableName()> t
 where t.plugin_name = :pluginName
 and t.is_active = true
 order by t.record_id
-limit :offset, :rowCount
+limit :rowCount offset :offset
 ;
 >>
 

--- a/payment/src/main/resources/org/killbill/billing/payment/dao/PaymentSqlDao.sql.stg
+++ b/payment/src/main/resources/org/killbill/billing/payment/dao/PaymentSqlDao.sql.stg
@@ -89,7 +89,7 @@ from <tableName()> t
 join payment_methods pm on pm.id = t.payment_method_id
 where pm.plugin_name = :pluginName
 order by t.record_id asc
-limit :offset, :rowCount
+limit :rowCount offset :offset
 ;
 >>
 

--- a/payment/src/main/resources/org/killbill/billing/payment/dao/RefundSqlDao.sql.stg
+++ b/payment/src/main/resources/org/killbill/billing/payment/dao/RefundSqlDao.sql.stg
@@ -72,7 +72,7 @@ join payments p on p.id = t.payment_id
 join payment_methods pm on pm.id = p.payment_method_id
 where pm.plugin_name = :pluginName
 order by record_id
-limit :offset, :rowCount
+limit :rowCount offset :offset
 ;
 >>
 

--- a/tenant/src/main/resources/org/killbill/billing/tenant/dao/TenantKVSqlDao.sql.stg
+++ b/tenant/src/main/resources/org/killbill/billing/tenant/dao/TenantKVSqlDao.sql.stg
@@ -40,9 +40,9 @@ and  t.is_active
 >>
 
 markTenantKeyAsDeleted() ::= <<
-update <tableName()> t
-set t.is_active = false
-where t.id = :id
-<AND_CHECK_TENANT("t.")>
+update <tableName()>
+set is_active = false
+where id = :id
+<AND_CHECK_TENANT("")>
 ;
 >>

--- a/usage/src/main/resources/org/killbill/billing/usage/dao/RolledUpUsageSqlDao.sql.stg
+++ b/usage/src/main/resources/org/killbill/billing/usage/dao/RolledUpUsageSqlDao.sql.stg
@@ -31,6 +31,7 @@ and record_date >= :startDate
 and record_date \< :endDate
 and unit_type = :unitType
 <AND_CHECK_TENANT()>
+order by <recordIdField()> ASC
 ;
 >>
 
@@ -42,6 +43,7 @@ where subscription_id = :subscriptionId
 and record_date >= :startDate
 and record_date \< :endDate
 <AND_CHECK_TENANT()>
+order by <recordIdField()> ASC
 ;
 >>
 
@@ -53,6 +55,7 @@ where account_record_id = :accountRecordId
 and record_date >= :startDate
 and record_date \< :endDate
 <AND_CHECK_TENANT()>
+order by <recordIdField()> ASC
 ;
 >>
 

--- a/util/src/main/resources/org/killbill/billing/util/customfield/dao/CustomFieldSqlDao.sql.stg
+++ b/util/src/main/resources/org/killbill/billing/util/customfield/dao/CustomFieldSqlDao.sql.stg
@@ -31,10 +31,10 @@ tableValues() ::= <<
 historyTableName() ::= "custom_field_history"
 
 markTagAsDeleted() ::= <<
-update <tableName()> t
-set t.is_active = false
-where <idField("t.")> = :id
-<AND_CHECK_TENANT("t.")>
+update <tableName()>
+set is_active = false
+where <idField("")> = :id
+<AND_CHECK_TENANT("")>
 ;
 >>
 

--- a/util/src/main/resources/org/killbill/billing/util/entity/dao/EntitySqlDao.sql.stg
+++ b/util/src/main/resources/org/killbill/billing/util/entity/dao/EntitySqlDao.sql.stg
@@ -154,7 +154,7 @@ from <tableName()> t
 where <CHECK_TENANT("t.")>
 <andCheckSoftDeletionWithComma("t.")>
 order by t.<orderBy>
-limit :offset, :rowCount
+limit :rowCount offset :offset
 ;
 >>
 
@@ -270,7 +270,7 @@ from <tableName()> t
 where (<searchQuery("t.")>)
 <AND_CHECK_TENANT("t.")>
 order by <recordIdField("t.")> ASC
-limit :offset, :rowCount
+limit :rowCount offset :offset
 ;
 >>
 

--- a/util/src/main/resources/org/killbill/billing/util/tag/dao/TagDefinitionSqlDao.sql.stg
+++ b/util/src/main/resources/org/killbill/billing/util/tag/dao/TagDefinitionSqlDao.sql.stg
@@ -31,10 +31,10 @@ accountRecordIdValueWithComma() ::= ""
 historyTableName() ::= "tag_definition_history"
 
 markTagDefinitionAsDeleted() ::= <<
-update <tableName()> t
-set t.is_active = false
-where <idField("t.")> = :id
-<AND_CHECK_TENANT("t.")>
+update <tableName()>
+set is_active = false
+where <idField("")> = :id
+<AND_CHECK_TENANT("")>
 ;
 >>
 

--- a/util/src/main/resources/org/killbill/billing/util/tag/dao/TagSqlDao.sql.stg
+++ b/util/src/main/resources/org/killbill/billing/util/tag/dao/TagSqlDao.sql.stg
@@ -116,7 +116,7 @@ join (<userAndSystemTagDefinitions()>) td on td.id = t.tag_definition_id
 where (<searchQuery(tagAlias="t.", tagDefinitionAlias="td.")>)
 <AND_CHECK_TENANT("t.")>
 order by <recordIdField("t.")> ASC
-limit :offset, :rowCount
+limit :rowCount offset :offset
 ;
 >>
 

--- a/util/src/test/java/org/killbill/billing/util/dao/TestStringTemplateInheritance.java
+++ b/util/src/test/java/org/killbill/billing/util/dao/TestStringTemplateInheritance.java
@@ -125,7 +125,7 @@ public class TestStringTemplateInheritance extends UtilTestSuiteNoDB {
                                                                                                                                                           "from kombucha t\r?\n" +
                                                                                                                                                           "where t.tenant_record_id = :tenantRecordId\r?\n" +
                                                                                                                                                           "order by t.record_id\r?\n" +
-                                                                                                                                                          "limit :offset, :rowCount\r?\n" +
+                                                                                                                                                          "limit :rowCount offset :offset\r?\n" +
                                                                                                                                                           ";");
         assertPattern(kombucha.getInstanceOf("test").toString(), "select\r?\n" +
                                                                  "  t.record_id\r?\n" +


### PR DESCRIPTION
@dconcha

There is an error with the construct (a = ? OR (a IS NULL AND ? IS NULL)).  When this resolves to effectively, (a = NULL OR (a IS NULL AND NULL IS NULL)), Postgres throws an error saying it can't determine the data type of the NULL IS NULL term.  One solution is to use COALESCE, the other would be of the nature, (a = ? OR (a IS NULL AND (CAST ? AS NUMERIC(15, 9)) IS NULL)).

The syntax LIMIT x, y does not work on Postgres.  LIMIT x OFFSET y will work across MySQL, H2, and Postgres.

The statements with the added ORDER BY was foremost to fix failing unit tests, but may have wider implications.  See the case of https://github.com/rocketlawyer/killbill/blob/master/usage/src/test/java/org/killbill/billing/usage/dao/TestDefaultRolledUpUsageDao.java#L76.  The unit test breaks when the rows are not read back in 1-2-3 order.  Anecdotally, under the circumstances of the unit test, MySQL will yield the results as 1-2-3, while Postgres will yield 3-2-1, both of which are of course valid in the absence of an ORDER BY clause.  I did try looking over the other SELECT statements, but I don't have enough expertise to say which of them will misbehave without an ORDER BY.  There are many statements that do use ORDER BY so I'm inclined to believe it's there when necessary, not there when not necessary.  For now let's just keep this in mind should anyone report issues we cannot explain or reproduce.
